### PR TITLE
fix: Separate test and build jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Dir Cleaner CI
 
 on:
   push:
@@ -11,12 +11,18 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run Unit Test
       run: cargo test --verbose


### PR DESCRIPTION
## CONTEXT

We want to `separate the build and test steps` in the CI checks on PR for clarity