### PR TITLE
FEAT: Cleanup directory based on file size

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -3,7 +3,7 @@ use clap::{Arg, Command};
 const APP: &str = "Directory cleaner";
 pub struct Args {
     pub types: Vec<String>,
-    pub min_size: u64,
+    pub min_size: Option<u64>,
     pub dir: String,
 }
 
@@ -52,9 +52,9 @@ pub fn parse_args() -> Args {
         None => Vec::new(),
     };
 
-    let min_size = match arg.get_one::<u64>("size") {
-        Some(size) => *size,
-        None => 0,
+    let min_size: Option<u64> = match arg.get_one::<u64>("size") {
+        Some(size) => Some(*size),
+        None => None,
     };
 
     Args {

--- a/src/features/cleaner.rs
+++ b/src/features/cleaner.rs
@@ -23,7 +23,7 @@ pub fn directory_cleaner(dir: &String, paths_to_clear: &[String], size: u64) -> 
             let ext = path.extension().and_then(|ex| ex.to_str()).unwrap_or("");
 
             if paths_to_clear.iter().any(|p| ext == p) {
-                let metadata = fs::metadata(path)
+                fs::metadata(path)
                     .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
 
                 println!("Deleting file: {:?}", path);
@@ -31,7 +31,7 @@ pub fn directory_cleaner(dir: &String, paths_to_clear: &[String], size: u64) -> 
                     .with_context(|| format!("Failed to delete file: {:?}", path))?;
             }
         } else {
-            println!("File does not exist, {}", path.display())
+            eprintln!("File does not exist, {}", path.display())
         }
     }
 

--- a/src/features/cleaner_file_size.rs
+++ b/src/features/cleaner_file_size.rs
@@ -1,0 +1,36 @@
+use anyhow::{Context, Result};
+use std::fs;
+use walkdir::WalkDir;
+
+pub fn directory_cleaner_based_on_file_size(dir: &String, size: u64) -> Result<()> {
+    for entry in WalkDir::new(dir).into_iter() {
+        match entry {
+            Ok(dir) => {
+                let path = dir.path();
+    
+                if path.is_file() {
+                    let metadata = fs::metadata(path)
+                    .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
+        
+                    if metadata.len() >= size {
+                        fs::remove_file(path)
+                            .with_context(|| format!("Failed to delete file: {:?}", path))?;
+                    }
+                    
+                } else {
+                    eprintln!("File does not exist, {}", path.display())
+                }
+            },
+
+            Err(err) => {
+                eprintln!(
+                    "Encountered error trying to get file. operation proceeding..., {}",
+                    err
+                );
+            }
+            
+        }
+    }
+
+    Ok(())
+}

--- a/src/features/cleaner_file_size.rs
+++ b/src/features/cleaner_file_size.rs
@@ -7,20 +7,19 @@ pub fn directory_cleaner_based_on_file_size(dir: &String, size: u64) -> Result<(
         match entry {
             Ok(dir) => {
                 let path = dir.path();
-    
+
                 if path.is_file() {
                     let metadata = fs::metadata(path)
-                    .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
-        
+                        .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
+
                     if metadata.len() >= size {
                         fs::remove_file(path)
                             .with_context(|| format!("Failed to delete file: {:?}", path))?;
                     }
-                    
                 } else {
                     eprintln!("File does not exist, {}", path.display())
                 }
-            },
+            }
 
             Err(err) => {
                 eprintln!(
@@ -28,7 +27,6 @@ pub fn directory_cleaner_based_on_file_size(dir: &String, size: u64) -> Result<(
                     err
                 );
             }
-            
         }
     }
 

--- a/src/features/cleaner_file_type.rs
+++ b/src/features/cleaner_file_type.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
 
-pub fn directory_cleaner_based_on_file_type(dir: &String, paths_to_clear: &[String], _size: u64) -> Result<()> {
+pub fn directory_cleaner_based_on_file_type(dir: &String, paths_to_clear: &[String]) -> Result<()> {
     for entry in WalkDir::new(dir).into_iter().filter_map(|f| {
         match f {
             Ok(entry) => Some(entry), // Return valid entries

--- a/src/features/cleaner_file_type.rs
+++ b/src/features/cleaner_file_type.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
 
-pub fn directory_cleaner(dir: &String, paths_to_clear: &[String], size: u64) -> Result<()> {
+pub fn directory_cleaner_based_on_file_type(dir: &String, paths_to_clear: &[String], _size: u64) -> Result<()> {
     for entry in WalkDir::new(dir).into_iter().filter_map(|f| {
         match f {
             Ok(entry) => Some(entry), // Return valid entries

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,2 +1,3 @@
 // All features should be registered here
 pub mod cleaner_file_type;
+pub mod cleaner_file_size;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,3 +1,3 @@
 // All features should be registered here
-pub mod cleaner_file_type;
 pub mod cleaner_file_size;
+pub mod cleaner_file_type;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,2 +1,2 @@
 // All features should be registered here
-pub mod cleaner;
+pub mod cleaner_file_type;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
     println!("File types to clean: {:?}", args.types);
     println!("Minimum file size: {} bytes", args.min_size);
 
-    features::cleaner::directory_cleaner(&args.dir, &args.types, args.min_size)?;
+    features::cleaner_file_type::directory_cleaner_based_on_file_type(&args.dir, &args.types, args.min_size)?;
 
     println!("Cleaning completed successfully.");
 
@@ -32,7 +32,7 @@ mod tests {
 
         let file_types = vec!["txt".to_string()];
         let dir_str = temp_dir.path().to_str().unwrap().to_string();
-        features::cleaner::directory_cleaner(&dir_str, &file_types, 500)?;
+        features::cleaner_file_type::directory_cleaner_based_on_file_type(&dir_str, &file_types, 500)?;
 
         assert!(!file_path.exists(), "File should have been deleted");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,16 +47,24 @@ mod tests {
     fn test_directory_cleaner_should_delete_files_greater_than_the_specified_min_size() -> Result<()>
     {
         let temp_dir = tempdir()?;
-        let file_path = temp_dir.path().join("test.txt");
-        let file = File::create(&file_path)?;
-        file.set_len(3000)?; // 3000 bytes
+        let file_path_1 = temp_dir.path().join("test1.txt");
+        let file_path_2 = temp_dir.path().join("test2.txt");
+        let file_1 = File::create(&file_path_1)?;
+        let file_2 = File::create(&file_path_2)?;
+        file_1.set_len(4000)?; // 3000 bytes
+        file_2.set_len(500)?; // 500 bytes
 
         let dir_str = temp_dir.path().to_str().unwrap().to_string();
         features::cleaner_file_size::directory_cleaner_based_on_file_size(&dir_str, 2000)?;
 
         assert!(
-            !file_path.exists(),
+            !file_path_1.exists(),
             "File should be deleted as it's more than the minimum size"
+        );
+
+        assert!(
+            file_path_2.exists(),
+            "File should not be deleted as it's less than the minimum size"
         );
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,20 +44,21 @@ mod tests {
     }
 
     #[test]
-    fn test_directory_cleaner_should_delete_files_greater_than_the_specified_min_size() -> Result<()> {
+    fn test_directory_cleaner_should_delete_files_greater_than_the_specified_min_size() -> Result<()>
+    {
         let temp_dir = tempdir()?;
         let file_path = temp_dir.path().join("test.txt");
         let file = File::create(&file_path)?;
         file.set_len(3000)?; // 3000 bytes
-    
+
         let dir_str = temp_dir.path().to_str().unwrap().to_string();
         features::cleaner_file_size::directory_cleaner_based_on_file_size(&dir_str, 2000)?;
-    
+
         assert!(
             !file_path.exists(),
             "File should be deleted as it's more than the minimum size"
         );
-        
+
         Ok(())
     }
 }


### PR DESCRIPTION
https://github.com/users/yahayaohinoyi/projects/4/views/1?pane=issue&itemId=79800266
## CONTEXT

We want to delete files from a directory based on a specified size. Meaning any files greater than the size should be deleted/

## HOW THIS WAS TESTED

`Unit tests`

`Manually`
- Create a dummy folder in your project dir for testing with two files; say `text1.txt` and `text2.txt`
- Append to the first file 500 bytes of data and the second 4000bytes of data
- Say we want to delete file sizes greater 1000bytes; run `cargo run -- -d "data/text.txt" -s 1000 `
- Notice only one file got deleted; the 4000 bytes file