### PR TITLE
FEAT: Cleanup directory based on duplicate file

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -6,6 +6,7 @@ pub struct Args {
     pub min_size: Option<u64>,
     pub dir: String,
     pub dry_run: bool,
+    pub remove_duplicates: bool,
 }
 
 pub fn parse_args() -> Args {
@@ -36,11 +37,19 @@ pub fn parse_args() -> Args {
         )
         .arg(
             Arg::new("dry_run")
-                .short('r')
+                .short('n')
                 .long("dryrun")
                 .required(false)
                 .value_parser(clap::value_parser!(bool))
                 .help("Dry run"),
+        )
+        .arg(
+            Arg::new("remove_duplicates")
+                .short('r')
+                .long("dedup")
+                .required(false)
+                .value_parser(clap::value_parser!(bool))
+                .help("Remove Duplicate"),
         )
         .get_matches();
 
@@ -71,10 +80,16 @@ pub fn parse_args() -> Args {
         None => false,
     };
 
+    let remove_duplicates: bool = match arg.get_one::<bool>("remove_duplicates") {
+        Some(dr) => *dr,
+        None => false,
+    };
+
     Args {
         types,
         min_size,
         dir,
         dry_run,
+        remove_duplicates,
     }
 }

--- a/src/features/cleaner_file_duplicate.rs
+++ b/src/features/cleaner_file_duplicate.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use colored::*;
+use std::collections::HashSet;
+use std::fs;
+use walkdir::WalkDir;
+
+fn get_file_key(file_name: Option<&std::ffi::OsStr>, file_size: u64) -> Option<String> {
+    file_name.and_then(|name| name.to_str()).map(|name| {
+        // Extract the first part of the file name, before any whitespace or special characters
+        let first_part = name.split_whitespace().next().unwrap_or("");
+        format!("{}{}", first_part, file_size)
+    })
+}
+
+pub fn directory_cleaner_based_on_duplicate_files(directory: &String, dry_run: bool) -> Result<()> {
+    let mut set: HashSet<String> = HashSet::new();
+    for entry in WalkDir::new(directory).into_iter() {
+        match entry {
+            Ok(dir) => {
+                let path = dir.path();
+
+                if path.is_file() {
+                    let metadata = fs::metadata(path)
+                        .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
+
+                    // use first word in filename + filesize as they key till we think of something
+                    // better
+
+                    let file_key = get_file_key(path.file_name(), metadata.len());
+
+                    match file_key {
+                        Some(file_key) => {
+                            if set.contains(&file_key) {
+                                if !dry_run {
+                                    fs::remove_file(path).with_context(|| {
+                                        format!("Failed to delete file: {:?}", path)
+                                    })?;
+                                } else {
+                                    if let Some(pth) = path.to_str() {
+                                        println!(
+                                            "\n {} could have been deleted",
+                                            pth.bold().yellow()
+                                        );
+                                    }
+                                }
+                            } else {
+                                set.insert(file_key);
+                            }
+                        }
+
+                        None => {}
+                    }
+                } else {
+                    eprintln!("File does not exist, {}", path.display())
+                }
+            }
+
+            Err(err) => {
+                eprintln!(
+                    "Encountered error trying to get file. operation proceeding..., {}",
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/features/cleaner_file_duplicate.rs
+++ b/src/features/cleaner_file_duplicate.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
-use colored::*;
 use std::collections::HashSet;
 use std::fs;
 use walkdir::WalkDir;
+
+use super::utils::delete_file;
 
 fn get_file_key(file_name: Option<&std::ffi::OsStr>, file_size: u64) -> Option<String> {
     file_name.and_then(|name| name.to_str()).map(|name| {
@@ -31,18 +32,7 @@ pub fn directory_cleaner_based_on_duplicate_files(directory: &String, dry_run: b
                     match file_key {
                         Some(file_key) => {
                             if set.contains(&file_key) {
-                                if !dry_run {
-                                    fs::remove_file(path).with_context(|| {
-                                        format!("Failed to delete file: {:?}", path)
-                                    })?;
-                                } else {
-                                    if let Some(pth) = path.to_str() {
-                                        println!(
-                                            "\n {} could have been deleted",
-                                            pth.bold().yellow()
-                                        );
-                                    }
-                                }
+                                delete_file(path, dry_run)?;
                             } else {
                                 set.insert(file_key);
                             }

--- a/src/features/cleaner_file_size.rs
+++ b/src/features/cleaner_file_size.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
-use colored::*;
 use std::fs;
 use walkdir::WalkDir;
+
+use super::utils::delete_file;
 
 pub fn directory_cleaner_based_on_file_size(
     directory: &String,
@@ -18,14 +19,7 @@ pub fn directory_cleaner_based_on_file_size(
                         .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
 
                     if metadata.len() >= size {
-                        if !dry_run {
-                            fs::remove_file(path)
-                                .with_context(|| format!("Failed to delete file: {:?}", path))?;
-                        } else {
-                            if let Some(pth) = path.to_str() {
-                                println!("\n {} could have been deleted", pth.bold().yellow());
-                            }
-                        }
+                        delete_file(path, dry_run)?;
                     }
                 } else {
                     eprintln!("File does not exist, {}", path.display())

--- a/src/features/cleaner_file_type.rs
+++ b/src/features/cleaner_file_type.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
-use colored::*;
 use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
+
+use crate::features::utils::delete_file;
 
 pub fn directory_cleaner_based_on_file_type(
     dir: &String,
@@ -33,14 +34,7 @@ pub fn directory_cleaner_based_on_file_type(
 
                 println!("Deleting file: {:?}", path);
 
-                if !dry_run {
-                    fs::remove_file(path)
-                        .with_context(|| format!("Failed to delete file: {:?}", path))?;
-                } else {
-                    if let Some(pth) = path.to_str() {
-                        println!("\n {} could have been deleted", pth.bold().yellow());
-                    }
-                }
+                delete_file(path, dry_run)?;
             }
         } else {
             eprintln!("File does not exist, {}", path.display())

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,3 +1,4 @@
 // All features should be registered here
+pub mod cleaner_file_duplicate;
 pub mod cleaner_file_size;
 pub mod cleaner_file_type;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -2,3 +2,4 @@
 pub mod cleaner_file_duplicate;
 pub mod cleaner_file_size;
 pub mod cleaner_file_type;
+pub mod utils;

--- a/src/features/utils.rs
+++ b/src/features/utils.rs
@@ -1,0 +1,15 @@
+use anyhow::{Context, Result};
+use colored::*;
+use std::fs;
+
+pub fn delete_file(path: &std::path::Path, dry_run: bool) -> Result<()> {
+    if !dry_run {
+        fs::remove_file(path).with_context(|| format!("Failed to delete file: {:?}", path))?;
+    } else {
+        if let Some(pth) = path.to_str() {
+            println!("\n {} could have been deleted", pth.bold().yellow());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
https://github.com/users/yahayaohinoyi/projects/4?pane=issue&itemId=79817740

## CONTEXT
We want to clean directories based on files that have similar content

## DESCRIPTION
Presently, I'm using `first_string_in_file_name_before_whitespace + filesize` as the key to tell if a file is similar to another. This is the simplest way I could think of.

## HOW THIS WAS TESTED
`Unit tests`
`Manually`

- Create a folder with 3 different files but the same prefix before the space character; `data/test 1.txt`, `data/test 2.txt`, `data/test 2.txt`
- Ensure the content of two of these files are same
- run the code and notice one of the files with same content got deleted